### PR TITLE
Fixing signalr iOS message with data

### DIFF
--- a/packages/signalr/index.ios.ts
+++ b/packages/signalr/index.ios.ts
@@ -66,7 +66,7 @@ export class Signalr extends SignalrCommon {
 
   emit(event: string, ...payload: any[]): void {
     if (this.signalrController != null || this.signalrController != undefined) {
-      this.signalrController.setSendWithEventNameDataCompletion(event, JSON.stringify(payload),(p1:any)=>{});
+      this.signalrController.setSendWithEventNameDataCompletion(event, payload,(p1:any)=>{});
     }
   }
 

--- a/packages/signalr/platforms/ios/PodFile
+++ b/packages/signalr/platforms/ios/PodFile
@@ -1,2 +1,2 @@
 pod 'SwiftSignalRClient'
-pod 'SwiftyJSON', '~> 4.0'
+pod 'SwiftyJSON', '~> 5.0'

--- a/packages/signalr/platforms/ios/src/SignalrForNs.swift
+++ b/packages/signalr/platforms/ios/src/SignalrForNs.swift
@@ -173,8 +173,12 @@ public class SignalrForNs:NSObject{
          
 
         // Envía los argumentos como una lista de elementos 'Encodable'
-      let jsonData = JSON(data ?? NSNull())
-      arguments.append(EncodableJSON(jsonData))
+      if let dataArray = data as? [Any] {
+        for item in dataArray {
+          let jsonData = JSON(item ?? NSNull())
+          arguments.append(EncodableJSON(jsonData))
+        }
+      }
 
       print("setSend \(arguments)")
         signalr.invoke(method: eventName, arguments: arguments) { error in


### PR DESCRIPTION
Fix for #3 - These changes help solve issue related to iOS message data.

## What was the issue?

The latest changes resulted in the data being sent as a JSON string. Also it was noted that the *whole* data array was being passed in `arguments`.

For example:
```js
connection.emit('subscribe', { ids: [ '1', '2' ]});
```
Resulted in the following payload to SignalR Server:
```json
{
  "type": 1,
  "invocationId": "1",
  "arguments": ["[{\"ids\": [\"1\", \"2\"]}]"],
  "target": "subscribe",
  "streamIds": []
}
```
`arguments` has 2 issues:
1. It is sending the data as an array, and not sending the object.
2. It is sending the data as a JSON string rather than an object.

## How was this fixed?

1. The `emit` function has been changed so that the `payload` is not transformed to a JSON string. This means that in Swift a Data object is received.
2. Since in the `emit` function the spread operator is used (`...payload`) - it means that the `payload` will always be an array. Therefore for us to be able to add items to the `arguments` array in Swift code we must loop over the `data`.
3. For each item in the `data` array, it is then converted to `Encodable` compatible data.

## My Tests

### String
```js
connection.emit("subscribe", "TEST");
```
Message to server:
```json
{
  "target": "subscribe",
  "streamIds": [],
  "type": 1,
  "arguments": [
    "TEST"
  ],
  "invocationId": "1"
}
```
### Boolean
```js
connection.emit("subscribe", true);
```
Message to server:
```json
{
  "target": "subscribe",
  "streamIds": [],
  "type": 1,
  "arguments": [
    true
  ],
  "invocationId": "2"
}
```
### Number
```js
connection.emit("subscribe", 100);
```
Message to server:
```json
{
  "target": "subscribe",
  "streamIds": [],
  "type": 1,
  "arguments": [
    100
  ],
  "invocationId": "3"
}
```
### Array of Numbers
```js
connection.emit("subscribe", [100, 200]);
```
Message to server:
```json
{
  "target": "subscribe",
  "streamIds": [],
  "type": 1,
  "arguments": [
    [
      100,
      200
    ]
  ],
  "invocationId": "4"
}
```
### Complex Object
```js

connection.emit("subscribe", {
  ids: ['1', '2'],
});
```
Message to server:
```json
{
  "target": "subscribe",
  "streamIds": [],
  "type": 1,
  "arguments": [
    {
      "securityIds": [
        "1",
        "2"
      ]
    }
  ],
  "invocationId": "5"
}
```